### PR TITLE
remove encoding for the open statement in the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 def read(f):
     here = os.path.abspath(os.path.dirname(__file__))
-    return open(os.path.join(here, f), encoding='utf-8').read().strip()
+    return open(os.path.join(here, f)).read().strip()
 
 
 setup(


### PR DESCRIPTION
This is not compatible with older python versions.
